### PR TITLE
use Meson `link_args` for LDFLAGS and install correct libc++abi

### DIFF
--- a/.github/workflows/clang.yml
+++ b/.github/workflows/clang.yml
@@ -11,7 +11,7 @@ jobs:
         with:
           version: 15
           platform: x64
-      - run: sudo apt install -y libc++-15-dev lld-15
+      - run: sudo apt install -y libc++-15-dev libc++abi-15-dev
       - run: pip install meson ninja
-      - run: CXX=clang++-15 CXX_LD=lld LDFLAGS=-L /usr/lib/llvm-15/lib meson setup build
+      - run: CXX=clang++-15 meson setup build
       - run: meson test -C build -v

--- a/meson.build
+++ b/meson.build
@@ -15,17 +15,19 @@ cppcompiler = meson.get_compiler('cpp').get_argument_syntax()
 if not meson.is_subproject()
 
 # テストプロジェクト用の設定追加
+ldflags = []
 if cppcompiler == 'msvc'
     # VSプロジェクトに編集しうるファイルを追加する
     vs_files = ['include/rivet.hpp']
-    options = ['/std:c++latest', '/source-charset:utf-8', '/Zc:__cplusplus']
+    cxxflags = ['/std:c++latest', '/source-charset:utf-8', '/Zc:__cplusplus']
 elif cppcompiler == 'gcc'
     vs_files = []
-    options = []
+    cxxflags = []
     if meson.get_compiler('cpp').get_id() == 'clang'
-        options = ['-stdlib=libc++', '-fexperimental-library']
+        cxxflags = ['-stdlib=libc++', '-fexperimental-library']
+        ldflags = ['-stdlib=libc++', '-fexperimental-library']
     else
-        options = []
+        cxxflags = []
     endif
 endif
 
@@ -33,19 +35,19 @@ endif
 boostut_dep = subproject('boost.ut').get_variable('boostut_dep')
 
 # テスト
-exe = executable('rivet_test', 'test/rivet_test.cpp', include_directories : include_directories('include'), extra_files : vs_files, cpp_args : options, dependencies : [boostut_dep])
+exe = executable('rivet_test', 'test/rivet_test.cpp', include_directories : include_directories('include'), extra_files : vs_files, cpp_args : cxxflags, link_args : ldflags, dependencies : [boostut_dep])
 test('rivet test', exe)
 
 else
 
 # ライブラリ利用時の設定追加
 if cppcompiler == 'msvc'
-    options = ['/std:c++latest', '/source-charset:utf-8']
+    cxxflags = ['/std:c++latest', '/source-charset:utf-8']
 elif cppcompiler == 'gcc'
-    options = []
+    cxxflags = []
 endif
 
 # subprojectとして構築時は依存オブジェクトの宣言だけしとく
-rivet_dep = declare_dependency(include_directories : include_directories('include'), cpp_args : options)
+rivet_dep = declare_dependency(include_directories : include_directories('include'), cpp_args : cxxflags)
 
 endif


### PR DESCRIPTION
clang++15 needs some extra arguments in order to find and link against its version-specific `libc++`.

In addition to the extra `libc++` package requirement mentioned [here][] (for standard library headers, etc) it also needs its specific `libc++abi` to link the output.

Note that because of the Meson build file, the end user needs to have `libc++-dev` and `libc++abi-dev` installed if they want to build rivet with Clang. A lot of distributions (like [Debian][] for instance) don't automatically package them together because Clang can use GCC's `libstdc++` instead and they prefer that. You should consider whether rivet is compatible with `libstdc++` (I think it probably is) and give users the choice of which C++ library they want to use.

[here]: https://twitter.com/waybeforenow/status/1610907992530235392
[Debian]: https://packages.debian.org/bullseye/clang-11